### PR TITLE
Fix motorsport image references and Eleventy build errors

### DIFF
--- a/src/content/pages/motorsport.html
+++ b/src/content/pages/motorsport.html
@@ -67,30 +67,30 @@ permalink: "/motorsport/"
             <!--Picture 1-->
 
             <picture class="cs-picture cs-picture1 ">
-                <source media="(max-width: 1024px)" srcset="{% getUrl '/assets/images/carLine.JPG' | resize({ width: 498, height: 168 }) | avif %}" type="image/avif">
-                <source media="(max-width: 1024px)" srcset="{% getUrl '/assets/images/carLine.JPG' | resize({ width: 498, height: 168 }) | webp %}" type="image/webp">
-                <source media="(max-width: 1024px)" srcset="{% getUrl '/assets/images/carLine.JPG' | resize({ width: 498, height: 168 }) | jpeg %}" type="image/jpeg">
+                <source media="(max-width: 1024px)" srcset="{% getUrl '/assets/images/carLine.jpg' | resize({ width: 498, height: 168 }) | avif %}" type="image/avif">
+                <source media="(max-width: 1024px)" srcset="{% getUrl '/assets/images/carLine.jpg' | resize({ width: 498, height: 168 }) | webp %}" type="image/webp">
+                <source media="(max-width: 1024px)" srcset="{% getUrl '/assets/images/carLine.jpg' | resize({ width: 498, height: 168 }) | jpeg %}" type="image/jpeg">
                 <!--Desktop Image-->
-                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/carLine.JPG' | resize({ width:781 , height: 262 }) | avif %}" type="image/avif">
-                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/carLine.JPG' | resize({ width:781 , height: 262 }) | webp %}" type="image/webp">
-                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/carLine.JPG' | resize({ width:781 , height: 262 }) | jpeg %}" type="image/jpeg">
-                <img src="{% getUrl '/assets/images/carLine.JPG' | resize({ width: 424, height: 190 }) | jpeg %}" alt="library" width=" 424" height="190 " loading="lazy" decoding="async">
+                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/carLine.jpg' | resize({ width:781 , height: 262 }) | avif %}" type="image/avif">
+                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/carLine.jpg' | resize({ width:781 , height: 262 }) | webp %}" type="image/webp">
+                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/carLine.jpg' | resize({ width:781 , height: 262 }) | jpeg %}" type="image/jpeg">
+                <img src="{% getUrl '/assets/images/carLine.jpg' | resize({ width: 424, height: 190 }) | jpeg %}" alt="library" width=" 424" height="190 " loading="lazy" decoding="async">
             </picture>
             <!--Picture 2-->
             <picture class="cs-picture cs-picture2 ">
                 <!--Mobile Image-->
-                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/astonMartin.JPG' | resize({ width:376, height:210 , position: 'attention'})  | avif %}" type="image/avif">
-                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/astonMartin.JPG' | resize({ width:376, height:210 , position: 'attention'}) | webp %}" type="image/webp">
-                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/astonMartin.JPG' | resize({ width:376, height:210 , position: 'attention'}) | jpeg %}" type="image/jpeg">
+                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/astonMartin.jpg' | resize({ width:376, height:210 , position: 'attention'})  | avif %}" type="image/avif">
+                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/astonMartin.jpg' | resize({ width:376, height:210 , position: 'attention'}) | webp %}" type="image/webp">
+                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/astonMartin.jpg' | resize({ width:376, height:210 , position: 'attention'}) | jpeg %}" type="image/jpeg">
                 <!--Tablet Image-->
-                <source media="(max-width: 1024px)" srcset="{% getUrl '/assets/images/astonMartin.JPG' | resize({ width: 750 , height:534 , position: 'attention' }) | avif %}" type="image/avif">
-                <source media="(max-width: 1024px)" srcset="{% getUrl '/assets/images/astonMartin.JPG' | resize({ width: 750 , height:534 , position: 'attention' }) | webp %}" type="image/webp">
-                <source media="(max-width: 1024px)" srcset="{% getUrl '/assets/images/astonMartin.JPG' | resize({ width: 750 , height:534 , position: 'attention' }) | jpeg %}" type="image/jpeg">
+                <source media="(max-width: 1024px)" srcset="{% getUrl '/assets/images/astonMartin.jpg' | resize({ width: 750 , height:534 , position: 'attention' }) | avif %}" type="image/avif">
+                <source media="(max-width: 1024px)" srcset="{% getUrl '/assets/images/astonMartin.jpg' | resize({ width: 750 , height:534 , position: 'attention' }) | webp %}" type="image/webp">
+                <source media="(max-width: 1024px)" srcset="{% getUrl '/assets/images/astonMartin.jpg' | resize({ width: 750 , height:534 , position: 'attention' }) | jpeg %}" type="image/jpeg">
                 <!--Desktop Image-->
-                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/astonMartin.JPG' | resize({ width: 662 , height: 478, position: 'attention' }) | avif %}" type="image/avif">
-                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/astonMartin.JPG' | resize({ width: 662 , height: 478, position: 'attention' }) | webp %}" type="image/webp">
-                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/astonMartin.JPG' | resize({ width: 662 , height: 478, position: 'attention' }) | jpeg %}" type="image/jpeg">
-                <img src="{% getUrl '/assets/images/astonMartin.JPG' | resize({ width:571, height: 390 }) | jpeg %}" alt="library" width="571" height="390" loading="lazy" decoding="async">
+                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/astonMartin.jpg' | resize({ width: 662 , height: 478, position: 'attention' }) | avif %}" type="image/avif">
+                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/astonMartin.jpg' | resize({ width: 662 , height: 478, position: 'attention' }) | webp %}" type="image/webp">
+                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/astonMartin.jpg' | resize({ width: 662 , height: 478, position: 'attention' }) | jpeg %}" type="image/jpeg">
+                <img src="{% getUrl '/assets/images/astonMartin.jpg' | resize({ width:571, height: 390 }) | jpeg %}" alt="library" width="571" height="390" loading="lazy" decoding="async">
             </picture>
             <!--Picture 3-->
 
@@ -130,19 +130,18 @@ permalink: "/motorsport/"
 
             <picture class="cs-picture cs-picture5 ">
                 <!--Mobile Image-->
-                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/goldWheel.jpg' | resize({ width:276, height:210, position: 'botton' })  | avif %}" type="image/avif">
-                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/goldWheel.jpg' | resize({ width:276, height:210, position: 'botton' }) | webp %}" type="image/webp">
-                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/goldWheel.jpg' | resize({ width:276, height:210, position: 'botton' }) | jpeg %}" type="image/jpeg">
+                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/goldWheel.jpg' | resize({ width:276, height:210, position: 'bottom' })  | avif %}" type="image/avif">
+                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/goldWheel.jpg' | resize({ width:276, height:210, position: 'bottom' }) | webp %}" type="image/webp">
+                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/goldWheel.jpg' | resize({ width:276, height:210, position: 'bottom' }) | jpeg %}" type="image/jpeg">
                 <!--Tablet Image-->
-                <source media="(max-width: 1024px)" srcset="{% getUrl '/assets/images/goldWheel.jpg' | resize({ width: 556 , height: 534, position: 'botton' }) | avif %}" type="image/avif">
-                <source media="(max-width: 1024px)" srcset="{% getUrl '/assets/images/goldWheel.jpg' | resize({ width: 556 , height: 534, position: 'botton' }) | webp %}" type="image/webp">
-                <source media="(max-width: 1024px)" srcset="{% getUrl '/assets/images/goldWheel.jpg' | resize({ width: 556 , height: 534, position: 'botton' }) | jpeg %}" type="image/jpeg">
+                <source media="(max-width: 1024px)" srcset="{% getUrl '/assets/images/goldWheel.jpg' | resize({ width: 556 , height: 534, position: 'bottom' }) | avif %}" type="image/avif">
+                <source media="(max-width: 1024px)" srcset="{% getUrl '/assets/images/goldWheel.jpg' | resize({ width: 556 , height: 534, position: 'bottom' }) | webp %}" type="image/webp">
+                <source media="(max-width: 1024px)" srcset="{% getUrl '/assets/images/goldWheel.jpg' | resize({ width: 556 , height: 534, position: 'bottom' }) | jpeg %}" type="image/jpeg">
                 <!--Desktop Image-->
-                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/goldWheel.jpg' | resize({ width: 499 , height: 681, position: 'botton' }) | avif %}" type="image/avif">
-                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/goldWheel.jpg' | resize({ width: 499 , height: 681, position: 'botton' }) | webp %}" type="image/webp">
-                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/goldWheel.jpg' | resize({ width: 499 , height: 681, position: 'botton' }) | jpeg %}" type="image/jpeg">
-                <img src="{% getUrl '/assets/images/goldWheel.jpg' | resize({ width:268, height: 190, position: 'botton }) | jpeg %}" alt="library" width="268" height="390" loading="lazy" decoding="async">
-            </picture>
+                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/goldWheel.jpg' | resize({ width: 499 , height: 681, position: 'bottom' }) | avif %}" type="image/avif">
+                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/goldWheel.jpg' | resize({ width: 499 , height: 681, position: 'bottom' }) | webp %}" type="image/webp">
+                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/goldWheel.jpg' | resize({ width: 499 , height: 681, position: 'bottom' }) | jpeg %}" type="image/jpeg">
+                <img src="{% getUrl '/assets/images/goldWheel.jpg' | resize({ width:268, height: 190, position: 'bottom' }) | jpeg %}" alt="library" width="268" height="390" loading="lazy" decoding="async">
             <!--Picture 6-->
 
             <picture class="cs-picture cs-picture6 ">
@@ -156,69 +155,69 @@ permalink: "/motorsport/"
 
             <picture class="cs-picture cs-picture7 ">
                 <!--Mobile Image-->
-                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/alfaRomeoFront.JPG' | resize({ width:176, height:93 })  | avif %}" type="image/avif">
-                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/alfaRomeoFront.JPG' | resize({ width:176, height:93 }) | webp %}" type="image/webp">
-                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/alfaRomeoFront.JPG' | resize({ width:176, height:93 }) | jpeg %}" type="image/jpeg">
+                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/alfaRomeoFront.jpg' | resize({ width:176, height:93 })  | avif %}" type="image/avif">
+                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/alfaRomeoFront.jpg' | resize({ width:176, height:93 }) | webp %}" type="image/webp">
+                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/alfaRomeoFront.jpg' | resize({ width:176, height:93 }) | jpeg %}" type="image/jpeg">
                 <!--Tablet Image-->
-                <source media="(max-width: 1024px)" srcset="{% getUrl '/assets/images/alfaRomeoFront.JPG' | resize({ width: 363 , height: 255}) | avif %}" type="image/avif">
-                <source media="(max-width: 1024px)" srcset="{% getUrl '/assets/images/alfaRomeoFront.JPG' | resize({ width: 363 , height: 255}) | webp %}" type="image/webp">
-                <source media="(max-width: 1024px)" srcset="{% getUrl '/assets/images/alfaRomeoFront.JPG' | resize({ width: 363 , height: 255}) | jpeg %}" type="image/jpeg">
+                <source media="(max-width: 1024px)" srcset="{% getUrl '/assets/images/alfaRomeoFront.jpg' | resize({ width: 363 , height: 255}) | avif %}" type="image/avif">
+                <source media="(max-width: 1024px)" srcset="{% getUrl '/assets/images/alfaRomeoFront.jpg' | resize({ width: 363 , height: 255}) | webp %}" type="image/webp">
+                <source media="(max-width: 1024px)" srcset="{% getUrl '/assets/images/alfaRomeoFront.jpg' | resize({ width: 363 , height: 255}) | jpeg %}" type="image/jpeg">
                 <!--Desktop Image-->
-                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/alfaRomeoFront.JPG' | resize({ width: 315 , height: 223 }) | avif %}" type="image/avif">
-                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/alfaRomeoFront.JPG' | resize({ width: 315 , height: 223 }) | webp %}" type="image/webp">
-                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/alfaRomeoFront.JPG' | resize({ width: 315 , height: 223 }) | jpeg %}" type="image/jpeg">
-                <img src="{% getUrl '/assets/images/alfaRomeoFront.JPG' | resize({ width:273, height: 190 }) | jpeg %}" alt="library" width="273" height="190" loading="lazy" decoding="async">
+                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/alfaRomeoFront.jpg' | resize({ width: 315 , height: 223 }) | avif %}" type="image/avif">
+                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/alfaRomeoFront.jpg' | resize({ width: 315 , height: 223 }) | webp %}" type="image/webp">
+                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/alfaRomeoFront.jpg' | resize({ width: 315 , height: 223 }) | jpeg %}" type="image/jpeg">
+                <img src="{% getUrl '/assets/images/alfaRomeoFront.jpg' | resize({ width:273, height: 190 }) | jpeg %}" alt="library" width="273" height="190" loading="lazy" decoding="async">
             </picture>
             <!--Picture 8-->
 
             <picture class="cs-picture cs-picture8 ">
                 <!--Mobile Image-->
-                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/blackPorscheGT3.JPG' | resize({ width:176, height:93 })  | avif %}" type="image/avif">
-                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/blackPorscheGT3.JPG' | resize({ width:176, height:93 }) | webp %}" type="image/webp">
-                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/blackPorscheGT3.JPG' | resize({ width:176, height:93 }) | jpeg %}" type="image/jpeg">
+                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/blackPorscheGT3.jpg' | resize({ width:176, height:93 })  | avif %}" type="image/avif">
+                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/blackPorscheGT3.jpg' | resize({ width:176, height:93 }) | webp %}" type="image/webp">
+                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/blackPorscheGT3.jpg' | resize({ width:176, height:93 }) | jpeg %}" type="image/jpeg">
                 <!--Tablet Image-->
-                <source media="(max-width: 1024px)" srcset="{% getUrl '/assets/images/blackPorscheGT3.JPG' | resize({ width: 363 , height: 255}) | avif %}" type="image/avif">
-                <source media="(max-width: 1024px)" srcset="{% getUrl '/assets/images/blackPorscheGT3.JPG' | resize({ width: 363 , height: 255}) | webp %}" type="image/webp">
-                <source media="(max-width: 1024px)" srcset="{% getUrl '/assets/images/blackPorscheGT3.JPG' | resize({ width: 363 , height: 255}) | jpeg %}" type="image/jpeg">
+                <source media="(max-width: 1024px)" srcset="{% getUrl '/assets/images/blackPorscheGT3.jpg' | resize({ width: 363 , height: 255}) | avif %}" type="image/avif">
+                <source media="(max-width: 1024px)" srcset="{% getUrl '/assets/images/blackPorscheGT3.jpg' | resize({ width: 363 , height: 255}) | webp %}" type="image/webp">
+                <source media="(max-width: 1024px)" srcset="{% getUrl '/assets/images/blackPorscheGT3.jpg' | resize({ width: 363 , height: 255}) | jpeg %}" type="image/jpeg">
                 <!--Desktop Image-->
-                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/blackPorscheGT3.JPG' | resize({ width: 315 , height: 213 }) | avif %}" type="image/avif">
-                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/blackPorscheGT3.JPG' | resize({ width: 315 , height: 213 }) | webp %}" type="image/webp">
-                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/blackPorscheGT3.JPG' | resize({ width: 315 , height: 213 }) | jpeg %}" type="image/jpeg">
-                <img src="{% getUrl '/assets/images/blackPorscheGT3.JPG' | resize({ width:273, height: 190 }) | jpeg %}" alt="library" width="273" height="190" loading="lazy" decoding="async">
+                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/blackPorscheGT3.jpg' | resize({ width: 315 , height: 213 }) | avif %}" type="image/avif">
+                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/blackPorscheGT3.jpg' | resize({ width: 315 , height: 213 }) | webp %}" type="image/webp">
+                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/blackPorscheGT3.jpg' | resize({ width: 315 , height: 213 }) | jpeg %}" type="image/jpeg">
+                <img src="{% getUrl '/assets/images/blackPorscheGT3.jpg' | resize({ width:273, height: 190 }) | jpeg %}" alt="library" width="273" height="190" loading="lazy" decoding="async">
             </picture>
             <!--Picture 9-->
 
             <picture class="cs-picture cs-picture9 ">
                 <!--Mobile Image-->
-                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/porscheAndR8.JPG' | resize({ width:176, height:210 })  | avif %}" type="image/avif">
-                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/porscheAndR8.JPG' | resize({ width:176, height:210 }) | webp %}" type="image/webp">
-                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/porscheAndR8.JPG' | resize({ width:176, height:210 }) | jpeg %}" type="image/jpeg">
+                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/porscheAndR8.jpg' | resize({ width:176, height:210 })  | avif %}" type="image/avif">
+                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/porscheAndR8.jpg' | resize({ width:176, height:210 }) | webp %}" type="image/webp">
+                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/porscheAndR8.jpg' | resize({ width:176, height:210 }) | jpeg %}" type="image/jpeg">
                 <!--Tablet Image-->
-                <source media="(max-width: 1024px)" srcset="{% getUrl '/assets/images/porscheAndR8.JPG' | resize({ width: 363 , height: 534}) | avif %}" type="image/avif">
-                <source media="(max-width: 1024px)" srcset="{% getUrl '/assets/images/porscheAndR8.JPG' | resize({ width: 363 , height: 534}) | webp %}" type="image/webp">
-                <source media="(max-width: 1024px)" srcset="{% getUrl '/assets/images/porscheAndR8.JPG' | resize({ width: 363 , height: 534}) | jpeg %}" type="image/jpeg">
+                <source media="(max-width: 1024px)" srcset="{% getUrl '/assets/images/porscheAndR8.jpg' | resize({ width: 363 , height: 534}) | avif %}" type="image/avif">
+                <source media="(max-width: 1024px)" srcset="{% getUrl '/assets/images/porscheAndR8.jpg' | resize({ width: 363 , height: 534}) | webp %}" type="image/webp">
+                <source media="(max-width: 1024px)" srcset="{% getUrl '/assets/images/porscheAndR8.jpg' | resize({ width: 363 , height: 534}) | jpeg %}" type="image/jpeg">
                 <!--Desktop Image-->
-                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/porscheAndR8.JPG' | resize({ width: 313 , height: 478 }) | avif %}" type="image/avif">
-                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/porscheAndR8.JPG' | resize({ width: 313 , height: 478 }) | webp %}" type="image/webp">
-                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/porscheAndR8.JPG' | resize({ width: 313 , height: 478 }) | jpeg %}" type="image/jpeg">
-                <img src="{% getUrl '/assets/images/porscheAndR8.JPG' | resize({ width:268, height: 390 }) | jpeg %}" alt="library" width="268" height="390" loading="lazy" decoding="async">
+                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/porscheAndR8.jpg' | resize({ width: 313 , height: 478 }) | avif %}" type="image/avif">
+                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/porscheAndR8.jpg' | resize({ width: 313 , height: 478 }) | webp %}" type="image/webp">
+                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/porscheAndR8.jpg' | resize({ width: 313 , height: 478 }) | jpeg %}" type="image/jpeg">
+                <img src="{% getUrl '/assets/images/porscheAndR8.jpg' | resize({ width:268, height: 390 }) | jpeg %}" alt="library" width="268" height="390" loading="lazy" decoding="async">
             </picture>
             <!--Picture 10-->
 
             <picture class="cs-picture cs-picture10">
                 <!--Mobile Image-->
-                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/orangePorsche.JPG' | resize({ width:276, height:210 })  | avif %}" type="image/avif">
-                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/orangePorsche.JPG' | resize({ width:276, height:210 }) | webp %}" type="image/webp">
-                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/orangePorsche.JPG' | resize({ width:276, height:210 }) | jpeg %}" type="image/jpeg">
+                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/orangePorsche.jpg' | resize({ width:276, height:210 })  | avif %}" type="image/avif">
+                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/orangePorsche.jpg' | resize({ width:276, height:210 }) | webp %}" type="image/webp">
+                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/orangePorsche.jpg' | resize({ width:276, height:210 }) | jpeg %}" type="image/jpeg">
                 <!--Tablet Image-->
-                <source media="(max-width: 1024px)" srcset="{% getUrl '/assets/images/orangePorsche.JPG' | resize({ width: 556 , height: 534}) | avif %}" type="image/avif">
-                <source media="(max-width: 1024px)" srcset="{% getUrl '/assets/images/orangePorsche.JPG' | resize({ width: 556 , height: 534}) | webp %}" type="image/webp">
-                <source media="(max-width: 1024px)" srcset="{% getUrl '/assets/images/orangePorsche.JPG' | resize({ width: 556 , height: 534}) | jpeg %}" type="image/jpeg">
+                <source media="(max-width: 1024px)" srcset="{% getUrl '/assets/images/orangePorsche.jpg' | resize({ width: 556 , height: 534}) | avif %}" type="image/avif">
+                <source media="(max-width: 1024px)" srcset="{% getUrl '/assets/images/orangePorsche.jpg' | resize({ width: 556 , height: 534}) | webp %}" type="image/webp">
+                <source media="(max-width: 1024px)" srcset="{% getUrl '/assets/images/orangePorsche.jpg' | resize({ width: 556 , height: 534}) | jpeg %}" type="image/jpeg">
                 <!--Desktop Image-->
-                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/orangePorsche.JPG' | resize({ width: 316 , height: 478 }) | avif %}" type="image/avif">
-                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/orangePorsche.JPG' | resize({ width: 316 , height: 478 }) | webp %}" type="image/webp">
-                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/orangePorsche.JPG' | resize({ width: 316 , height: 478 }) | jpeg %}" type="image/jpeg">
-                <img src="{% getUrl '/assets/images/orangePorsche.JPG' | resize({ width:268, height: 390 }) | jpeg %}" alt="library" width="268" height="390" loading="lazy" decoding="async">
+                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/orangePorsche.jpg' | resize({ width: 316 , height: 478 }) | avif %}" type="image/avif">
+                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/orangePorsche.jpg' | resize({ width: 316 , height: 478 }) | webp %}" type="image/webp">
+                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/orangePorsche.jpg' | resize({ width: 316 , height: 478 }) | jpeg %}" type="image/jpeg">
+                <img src="{% getUrl '/assets/images/orangePorsche.jpg' | resize({ width:268, height: 390 }) | jpeg %}" alt="library" width="268" height="390" loading="lazy" decoding="async">
             </picture>
             <!--Picture 11-->
             <picture class="cs-picture cs-picture11">
@@ -228,18 +227,18 @@ permalink: "/motorsport/"
             </picture>
             <picture class="cs-picture cs-picture11 ">
                 <!--Mobile Image-->
-                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/motorsports/corneringBikes.JPG' | resize({ width:276, height:94 })  | avif %}" type="image/avif">
-                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/motorsports/corneringBikes.JPG' | resize({ width:276, height:94 }) | webp %}" type="image/webp">
-                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/motorsports/corneringBikes.JPG' | resize({ width:276, height:94 }) | jpeg %}" type="image/jpeg">
+                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/JPG/corneringBikes.JPG' | resize({ width:276, height:94 })  | avif %}" type="image/avif">
+                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/JPG/corneringBikes.JPG' | resize({ width:276, height:94 }) | webp %}" type="image/webp">
+                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/JPG/corneringBikes.JPG' | resize({ width:276, height:94 }) | jpeg %}" type="image/jpeg">
                 <!--Tablet Image-->
-                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/motorsports/corneringBikes.JPG' | resize({ width: 556 , height: 256}) | avif %}" type="image/avif">
-                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/motorsports/corneringBikes.JPG' | resize({ width: 556 , height: 256}) | webp %}" type="image/webp">
-                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/motorsports/corneringBikes.JPG' | resize({ width: 556 , height: 256}) | jpeg %}" type="image/jpeg">
+                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/JPG/corneringBikes.JPG' | resize({ width: 556 , height: 256}) | avif %}" type="image/avif">
+                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/JPG/corneringBikes.JPG' | resize({ width: 556 , height: 256}) | webp %}" type="image/webp">
+                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/JPG/corneringBikes.JPG' | resize({ width: 556 , height: 256}) | jpeg %}" type="image/jpeg">
                 <!--Desktop Image-->
-                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/motorsports/corneringBikes.JPG' | resize({ width: 316 , height: 478 }) | avif %}" type="image/avif">
-                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/motorsports/corneringBikes.JPG' | resize({ width: 316 , height: 478 }) | webp %}" type="image/webp">
-                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/motorsports/corneringBikes.JPG' | resize({ width: 316 , height: 478 }) | jpeg %}" type="image/jpeg">
-                <img src="{% getUrl '/assets/images/motorsports/corneringBikes.JPG' | resize({ width:268, height: 190 }) | jpeg %}" alt="library" width="268" height="190" loading="lazy" decoding="async">
+                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/JPG/corneringBikes.JPG' | resize({ width: 316 , height: 478 }) | avif %}" type="image/avif">
+                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/JPG/corneringBikes.JPG' | resize({ width: 316 , height: 478 }) | webp %}" type="image/webp">
+                <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/JPG/corneringBikes.JPG' | resize({ width: 316 , height: 478 }) | jpeg %}" type="image/jpeg">
+                <img src="{% getUrl '/assets/images/JPG/corneringBikes.JPG' | resize({ width:268, height: 190 }) | jpeg %}" alt="library" width="268" height="190" loading="lazy" decoding="async">
             </picture>
         </div>
     </div>

--- a/src/index.html
+++ b/src/index.html
@@ -169,14 +169,14 @@ tags: "sitemap" # content/content.json will make sure that all pages in content/
             <!--Middle image-->
             <picture class="cs-picture cs-picture3">
                 <!--Mobile Image-->
-                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/JPG/sunsetBike.jpg' | resize({ width:218, height: 225, position: 'bottom' })  | avif %}" type="image/avif">
-                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/JPG/sunsetBike.jpg' | resize({ width:218, height: 225, position: 'bottom' }) | webp %}" type="image/webp">
-                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/JPG/sunsetBike.jpg' | resize({ width:218, height: 225, position: 'bottom' }) | jpeg %}" type="image/jpeg">
+                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/JPG/sunsetBike.JPG' | resize({ width:218, height: 225, position: 'bottom' })  | avif %}" type="image/avif">
+                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/JPG/sunsetBike.JPG' | resize({ width:218, height: 225, position: 'bottom' }) | webp %}" type="image/webp">
+                <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/JPG/sunsetBike.JPG' | resize({ width:218, height: 225, position: 'bottom' }) | jpeg %}" type="image/jpeg">
                 <!--Tablet Image-->
-                <source media="(min-width: 601px)" srcset="{% getUrl '/assets/images/JPG/sunsetBike.jpg' | resize({ width: 218 , height: 225, position: 'bottom'}) | avif %}" type="image/avif">
-                <source media="(min-width: 601px)" srcset="{% getUrl '/assets/images/JPG/sunsetBike.jpg' | resize({ width: 218 , height: 225, position: 'bottom'}) | webp %}" type="image/webp">
-                <source media="(min-width: 601px)" srcset="{% getUrl '/assets/images/JPG/sunsetBike.jpg' | resize({ width: 218 , height: 225, position: 'bottom'}) | jpeg %}" type="image/jpeg">
-                <img loading="lazy" decoding="async"  src="{% getUrl '/assets/images/JPG/sunsetBike.jpg' | resize({ width:218, height: 225, position: 'bottom' }) | jpeg %}" alt="yellow porsche gt3 and yatch" width="218" height="225">
+                <source media="(min-width: 601px)" srcset="{% getUrl '/assets/images/JPG/sunsetBike.JPG' | resize({ width: 218 , height: 225, position: 'bottom'}) | avif %}" type="image/avif">
+                <source media="(min-width: 601px)" srcset="{% getUrl '/assets/images/JPG/sunsetBike.JPG' | resize({ width: 218 , height: 225, position: 'bottom'}) | webp %}" type="image/webp">
+                <source media="(min-width: 601px)" srcset="{% getUrl '/assets/images/JPG/sunsetBike.JPG' | resize({ width: 218 , height: 225, position: 'bottom'}) | jpeg %}" type="image/jpeg">
+                <img loading="lazy" decoding="async"  src="{% getUrl '/assets/images/JPG/sunsetBike.JPG' | resize({ width:218, height: 225, position: 'bottom' }) | jpeg %}" alt="yellow porsche gt3 and yatch" width="218" height="225">
 
             </picture>
         </div>


### PR DESCRIPTION
## Summary
- correct the motorsport gallery image references and resize options to match the actual assets
- fix the sunset Bike image reference casing on the home page so the sharp plugin can locate the file

## Testing
- npm run build:eleventy

------
https://chatgpt.com/codex/tasks/task_e_68e2eb8148348321b0851e9fc4599450