### PR TITLE
Remove invalid type attributes from fallback <img> elements

### DIFF
--- a/src/content/pages/creative-creation.html
+++ b/src/content/pages/creative-creation.html
@@ -117,7 +117,7 @@ permalink: "/creative_creation/"
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/JPG/JadeOnTopOfCar.JPG' | resize({ width:635, height:721}) | avif %}" type="image/avif">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/JPG/JadeOnTopOfCar.JPG' | resize({ width:635, height:721}) | webp %}" type="image/webp">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/JPG/JadeOnTopOfCar.JPG' | resize({ width:635, height:721}) | jpeg %}" type="image/jpeg">
-                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/JPG/JadeOnTopOfCar.JPG' | resize({ width:420, height:512})  | avif %}" type="image/avif" alt="building a new wall" width="420" height="512">
+                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/JPG/JadeOnTopOfCar.JPG' | resize({ width:420, height:512})  | avif %}" alt="building a new wall" width="420" height="512">
                 </picture>
                 <!-- To add more images, copy and paste this row's picture tags here in order from cs-picture-1 to cs-picture-3 and they will maintain the same layout-->
             </div>
@@ -136,7 +136,7 @@ permalink: "/creative_creation/"
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/JPG/holdingRose.JPG' | resize({ width:635, height:693}) | avif %}" type="image/avif">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/JPG/holdingRose.JPG' | resize({ width:635, height:693}) | webp %}" type="image/webp">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/JPG/holdingRose.JPG' | resize({ width:635, height:693}) | jpeg %}" type="image/jpeg">
-                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/JPG/holdingRose.JPG' | resize({ width:420, height:492})  | avif %}" type="image/avif" alt="building a new wall" width="420" height="492">
+                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/JPG/holdingRose.JPG' | resize({ width:420, height:492})  | avif %}" alt="building a new wall" width="420" height="492">
                 </picture>
                 <picture class="cs-picture cs-picture-2">
                     <!--Mobile Image-->
@@ -151,7 +151,7 @@ permalink: "/creative_creation/"
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/JPG/burningRose.jpg' | resize({ width:635, height:728}) | avif %}" type="image/avif">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/JPG/burningRose.jpg' | resize({ width:635, height:728}) | webp %}" type="image/webp">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/JPG/burningRose.jpg' | resize({ width:635, height:728}) | jpeg %}" type="image/jpeg">
-                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/JPG/burningRose.jpg' | resize({ width:420, height:517})  | avif %}" type="image/avif" alt="building a new wall" width="420" height="517">
+                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/JPG/burningRose.jpg' | resize({ width:420, height:517})  | avif %}" alt="building a new wall" width="420" height="517">
                 </picture>
                 <picture class="cs-picture cs-picture-3">
                     <!--Mobile Image-->
@@ -166,7 +166,7 @@ permalink: "/creative_creation/"
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/JPG/walkingAway.JPG' | resize({ width:635, height:886}) | avif %}" type="image/avif">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/JPG/walkingAway.JPG' | resize({ width:635, height:886}) | webp %}" type="image/webp">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/JPG/walkingAway.JPG' | resize({ width:635, height:886}) | jpeg %}" type="image/jpeg">
-                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/JPG/walkingAway.JPG' | resize({ width:420, height:629})  | avif %}" type="image/avif" alt="building a new wall" width="420" height="629">
+                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/JPG/walkingAway.JPG' | resize({ width:420, height:629})  | avif %}" alt="building a new wall" width="420" height="629">
                 </picture>
                 <!-- To add more images, copy and paste this row's picture tags here in order from cs-picture-1 to cs-picture-3 and they will maintain the same layout-->
             </div>
@@ -185,7 +185,7 @@ permalink: "/creative_creation/"
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/JPG/camera.JPG' | resize({ width:635, height:880}) | avif %}" type="image/avif">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/JPG/camera.JPG' | resize({ width:635, height:880}) | webp %}" type="image/webp">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/JPG/camera.JPG' | resize({ width:635, height:880}) | jpeg %}" type="image/jpeg">
-                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/JPG/camera.JPG' | resize({ width:420, height:625})  | avif %}" type="image/avif" alt="building a new wall" width="420" height="625">
+                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/JPG/camera.JPG' | resize({ width:420, height:625})  | avif %}" alt="building a new wall" width="420" height="625">
                 </picture>
                 <picture class="cs-picture cs-picture-2">
                     <!--Mobile Image-->
@@ -200,7 +200,7 @@ permalink: "/creative_creation/"
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/JPG/hero.jpeg' | resize({ width:635, height:636}) | avif %}" type="image/avif">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/JPG/hero.jpeg' | resize({ width:635, height:636}) | webp %}" type="image/webp">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/JPG/hero.jpeg' | resize({ width:635, height:636}) | jpeg %}" type="image/jpeg">
-                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/JPG/hero.jpeg' | resize({ width:420, height:452})  | avif %}" type="image/avif" alt="building a new wall" width="420" height="452">
+                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/JPG/hero.jpeg' | resize({ width:420, height:452})  | avif %}" alt="building a new wall" width="420" height="452">
                 </picture>
                 <picture class="cs-picture cs-picture-3">
                     <!--Mobile Image-->
@@ -215,7 +215,7 @@ permalink: "/creative_creation/"
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/JPG/heroSide.jpeg' | resize({ width:635, height:886}) | avif %}" type="image/avif">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/JPG/heroSide.jpeg' | resize({ width:635, height:886}) | webp %}" type="image/webp">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/JPG/heroSide.jpeg' | resize({ width:635, height:886}) | jpeg %}" type="image/jpeg">
-                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/JPG/heroSide.jpeg' | resize({ width:420, height:629})  | avif %}" type="image/avif" alt="building a new wall" width="420" height="629">
+                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/JPG/heroSide.jpeg' | resize({ width:420, height:629})  | avif %}" alt="building a new wall" width="420" height="629">
                 </picture>
 
                 <!-- To add more images, copy and paste this row's picture tags here in order from cs-picture-1 to cs-picture-3 and they will maintain the same layout-->

--- a/src/content/pages/motorsport.html
+++ b/src/content/pages/motorsport.html
@@ -351,7 +351,7 @@ permalink: "/motorsport/"
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/track2.jpg' | resize({ width:635, height:721}) | avif %}" type="image/avif">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/track2.jpg' | resize({ width:635, height:721}) | webp %}" type="image/webp">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/track2.jpg' | resize({ width:635, height:721}) | jpeg %}" type="image/jpeg">
-                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/track2.jpg' | resize({ width:420, height:512})  | avif %}" type="image/avif" alt="building a new wall" width="420" height="512">
+                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/track2.jpg' | resize({ width:420, height:512})  | avif %}" alt="building a new wall" width="420" height="512">
                 </picture>
                 <!-- Row 4-->
                 <picture class="cs-picture cs-picture-1">
@@ -396,7 +396,7 @@ permalink: "/motorsport/"
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/track2.jpg' | resize({ width:635, height:721}) | avif %}" type="image/avif">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/track2.jpg' | resize({ width:635, height:721}) | webp %}" type="image/webp">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/track2.jpg' | resize({ width:635, height:721}) | jpeg %}" type="image/jpeg">
-                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/track2.jpg' | resize({ width:420, height:512})  | avif %}" type="image/avif" alt="building a new wall" width="420" height="512">
+                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/track2.jpg' | resize({ width:420, height:512})  | avif %}" alt="building a new wall" width="420" height="512">
                 </picture>
                 <picture class="cs-picture cs-picture-1">
                     <!--Mobile Image-->
@@ -440,7 +440,7 @@ permalink: "/motorsport/"
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/track2.jpg' | resize({ width:635, height:721}) | avif %}" type="image/avif">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/track2.jpg' | resize({ width:635, height:721}) | webp %}" type="image/webp">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/track2.jpg' | resize({ width:635, height:721}) | jpeg %}" type="image/jpeg">
-                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/track2.jpg' | resize({ width:420, height:512})  | avif %}" type="image/avif" alt="building a new wall" width="420" height="512">
+                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/track2.jpg' | resize({ width:420, height:512})  | avif %}" alt="building a new wall" width="420" height="512">
                 </picture> <picture class="cs-picture cs-picture-1">
                 <!--Mobile Image-->
                 <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/lotusAndBike.jpg' | resize({ width:181, height:249})  | avif %}" type="image/avif">
@@ -483,7 +483,7 @@ permalink: "/motorsport/"
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/track2.jpg' | resize({ width:635, height:721}) | avif %}" type="image/avif">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/track2.jpg' | resize({ width:635, height:721}) | webp %}" type="image/webp">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/track2.jpg' | resize({ width:635, height:721}) | jpeg %}" type="image/jpeg">
-                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/track2.jpg' | resize({ width:420, height:512})  | avif %}" type="image/avif" alt="building a new wall" width="420" height="512">
+                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/track2.jpg' | resize({ width:420, height:512})  | avif %}" alt="building a new wall" width="420" height="512">
                 </picture>
                 <!-- To add more images, copy and paste this row's picture tags here in order from cs-picture-1 to cs-picture-3 and they will maintain the same layout-->
             </div>
@@ -502,7 +502,7 @@ permalink: "/motorsport/"
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/greenLotus.jpg' | resize({ width:635, height:693}) | avif %}" type="image/avif">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/greenLotus.jpg' | resize({ width:635, height:693}) | webp %}" type="image/webp">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/greenLotus.jpg' | resize({ width:635, height:693}) | jpeg %}" type="image/jpeg">
-                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/greenLotus.jpg' | resize({ width:420, height:492})  | avif %}" type="image/avif" alt="building a new wall" width="420" height="492">
+                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/greenLotus.jpg' | resize({ width:420, height:492})  | avif %}" alt="building a new wall" width="420" height="492">
                 </picture>
                 <picture class="cs-picture cs-picture-2">
                     <!--Mobile Image-->
@@ -517,7 +517,7 @@ permalink: "/motorsport/"
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/lowRider.jpg' | resize({ width:635, height:728}) | avif %}" type="image/avif">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/lowRider.jpg' | resize({ width:635, height:728}) | webp %}" type="image/webp">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/lowRider.jpg' | resize({ width:635, height:728}) | jpeg %}" type="image/jpeg">
-                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/lowRider.jpg' | resize({ width:420, height:517})  | avif %}" type="image/avif" alt="building a new wall" width="420" height="517">
+                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/lowRider.jpg' | resize({ width:420, height:517})  | avif %}" alt="building a new wall" width="420" height="517">
                 </picture>
                 <picture class="cs-picture cs-picture-3">
                     <!--Mobile Image-->
@@ -532,7 +532,7 @@ permalink: "/motorsport/"
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/porschePitStop.jpg' | resize({ width:635, height:886}) | avif %}" type="image/avif">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/porschePitStop.jpg' | resize({ width:635, height:886}) | webp %}" type="image/webp">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/porschePitStop.jpg' | resize({ width:635, height:886}) | jpeg %}" type="image/jpeg">
-                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/porschePitStop.jpg' | resize({ width:420, height:629})  | avif %}" type="image/avif" alt="building a new wall" width="420" height="629">
+                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/porschePitStop.jpg' | resize({ width:420, height:629})  | avif %}" alt="building a new wall" width="420" height="629">
                 </picture>
                 <picture class="cs-picture cs-picture-1">
                     <!--Mobile Image-->
@@ -547,7 +547,7 @@ permalink: "/motorsport/"
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/greenLotus.jpg' | resize({ width:635, height:693}) | avif %}" type="image/avif">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/greenLotus.jpg' | resize({ width:635, height:693}) | webp %}" type="image/webp">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/greenLotus.jpg' | resize({ width:635, height:693}) | jpeg %}" type="image/jpeg">
-                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/greenLotus.jpg' | resize({ width:420, height:492})  | avif %}" type="image/avif" alt="building a new wall" width="420" height="492">
+                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/greenLotus.jpg' | resize({ width:420, height:492})  | avif %}" alt="building a new wall" width="420" height="492">
                 </picture>
                 <picture class="cs-picture cs-picture-2">
                     <!--Mobile Image-->
@@ -562,7 +562,7 @@ permalink: "/motorsport/"
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/lowRider.jpg' | resize({ width:635, height:728}) | avif %}" type="image/avif">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/lowRider.jpg' | resize({ width:635, height:728}) | webp %}" type="image/webp">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/lowRider.jpg' | resize({ width:635, height:728}) | jpeg %}" type="image/jpeg">
-                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/lowRider.jpg' | resize({ width:420, height:517})  | avif %}" type="image/avif" alt="building a new wall" width="420" height="517">
+                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/lowRider.jpg' | resize({ width:420, height:517})  | avif %}" alt="building a new wall" width="420" height="517">
                 </picture>
                 <picture class="cs-picture cs-picture-3">
                     <!--Mobile Image-->
@@ -577,7 +577,7 @@ permalink: "/motorsport/"
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/porschePitStop.jpg' | resize({ width:635, height:886}) | avif %}" type="image/avif">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/porschePitStop.jpg' | resize({ width:635, height:886}) | webp %}" type="image/webp">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/porschePitStop.jpg' | resize({ width:635, height:886}) | jpeg %}" type="image/jpeg">
-                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/porschePitStop.jpg' | resize({ width:420, height:629})  | avif %}" type="image/avif" alt="building a new wall" width="420" height="629">
+                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/porschePitStop.jpg' | resize({ width:420, height:629})  | avif %}" alt="building a new wall" width="420" height="629">
                 </picture>
                 <picture class="cs-picture cs-picture-1">
                     <!--Mobile Image-->
@@ -592,7 +592,7 @@ permalink: "/motorsport/"
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/greenLotus.jpg' | resize({ width:635, height:693}) | avif %}" type="image/avif">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/greenLotus.jpg' | resize({ width:635, height:693}) | webp %}" type="image/webp">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/greenLotus.jpg' | resize({ width:635, height:693}) | jpeg %}" type="image/jpeg">
-                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/greenLotus.jpg' | resize({ width:420, height:492})  | avif %}" type="image/avif" alt="building a new wall" width="420" height="492">
+                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/greenLotus.jpg' | resize({ width:420, height:492})  | avif %}" alt="building a new wall" width="420" height="492">
                 </picture>
                 <picture class="cs-picture cs-picture-2">
                     <!--Mobile Image-->
@@ -607,7 +607,7 @@ permalink: "/motorsport/"
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/lowRider.jpg' | resize({ width:635, height:728}) | avif %}" type="image/avif">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/lowRider.jpg' | resize({ width:635, height:728}) | webp %}" type="image/webp">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/lowRider.jpg' | resize({ width:635, height:728}) | jpeg %}" type="image/jpeg">
-                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/lowRider.jpg' | resize({ width:420, height:517})  | avif %}" type="image/avif" alt="building a new wall" width="420" height="517">
+                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/lowRider.jpg' | resize({ width:420, height:517})  | avif %}" alt="building a new wall" width="420" height="517">
                 </picture>
                 <picture class="cs-picture cs-picture-3">
                     <!--Mobile Image-->
@@ -622,7 +622,7 @@ permalink: "/motorsport/"
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/porschePitStop.jpg' | resize({ width:635, height:886}) | avif %}" type="image/avif">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/porschePitStop.jpg' | resize({ width:635, height:886}) | webp %}" type="image/webp">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/porschePitStop.jpg' | resize({ width:635, height:886}) | jpeg %}" type="image/jpeg">
-                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/porschePitStop.jpg' | resize({ width:420, height:629})  | avif %}" type="image/avif" alt="building a new wall" width="420" height="629">
+                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/porschePitStop.jpg' | resize({ width:420, height:629})  | avif %}" alt="building a new wall" width="420" height="629">
                 </picture> <picture class="cs-picture cs-picture-1">
                 <!--Mobile Image-->
                 <source media="(max-width: 600px)" srcset="{% getUrl '/assets/images/greenLotus.jpg' | resize({ width:181, height:249})  | avif %}" type="image/avif">
@@ -636,7 +636,7 @@ permalink: "/motorsport/"
                 <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/greenLotus.jpg' | resize({ width:635, height:693}) | avif %}" type="image/avif">
                 <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/greenLotus.jpg' | resize({ width:635, height:693}) | webp %}" type="image/webp">
                 <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/greenLotus.jpg' | resize({ width:635, height:693}) | jpeg %}" type="image/jpeg">
-                <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/greenLotus.jpg' | resize({ width:420, height:492})  | avif %}" type="image/avif" alt="building a new wall" width="420" height="492">
+                <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/greenLotus.jpg' | resize({ width:420, height:492})  | avif %}" alt="building a new wall" width="420" height="492">
             </picture>
                 <picture class="cs-picture cs-picture-2">
                     <!--Mobile Image-->
@@ -651,7 +651,7 @@ permalink: "/motorsport/"
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/lowRider.jpg' | resize({ width:635, height:728}) | avif %}" type="image/avif">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/lowRider.jpg' | resize({ width:635, height:728}) | webp %}" type="image/webp">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/lowRider.jpg' | resize({ width:635, height:728}) | jpeg %}" type="image/jpeg">
-                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/lowRider.jpg' | resize({ width:420, height:517})  | avif %}" type="image/avif" alt="building a new wall" width="420" height="517">
+                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/lowRider.jpg' | resize({ width:420, height:517})  | avif %}" alt="building a new wall" width="420" height="517">
                 </picture>
                 <picture class="cs-picture cs-picture-3">
                     <!--Mobile Image-->
@@ -666,7 +666,7 @@ permalink: "/motorsport/"
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/porschePitStop.jpg' | resize({ width:635, height:886}) | avif %}" type="image/avif">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/porschePitStop.jpg' | resize({ width:635, height:886}) | webp %}" type="image/webp">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/porschePitStop.jpg' | resize({ width:635, height:886}) | jpeg %}" type="image/jpeg">
-                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/porschePitStop.jpg' | resize({ width:420, height:629})  | avif %}" type="image/avif" alt="building a new wall" width="420" height="629">
+                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/porschePitStop.jpg' | resize({ width:420, height:629})  | avif %}" alt="building a new wall" width="420" height="629">
                 </picture>
                 <!-- To add more images, copy and paste this row's picture tags here in order from cs-picture-1 to cs-picture-3 and they will maintain the same layout-->
             </div>
@@ -685,7 +685,7 @@ permalink: "/motorsport/"
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/hiddenPorsche.jpg' | resize({ width:635, height:880}) | avif %}" type="image/avif">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/hiddenPorsche.jpg' | resize({ width:635, height:880}) | webp %}" type="image/webp">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/hiddenPorsche.jpg' | resize({ width:635, height:880}) | jpeg %}" type="image/jpeg">
-                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/hiddenPorsche.jpg' | resize({ width:420, height:625})  | avif %}" type="image/avif" alt="building a new wall" width="420" height="625">
+                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/hiddenPorsche.jpg' | resize({ width:420, height:625})  | avif %}" alt="building a new wall" width="420" height="625">
                 </picture>
                 <picture class="cs-picture cs-picture-2">
                     <!--Mobile Image-->
@@ -700,7 +700,7 @@ permalink: "/motorsport/"
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/alfaRomeoTop.jpg' | resize({ width:635, height:636}) | avif %}" type="image/avif">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/alfaRomeoTop.jpg' | resize({ width:635, height:636}) | webp %}" type="image/webp">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/alfaRomeoTop.jpg' | resize({ width:635, height:636}) | jpeg %}" type="image/jpeg">
-                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/alfaRomeoTop.jpg' | resize({ width:420, height:452})  | avif %}" type="image/avif" alt="building a new wall" width="420" height="452">
+                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/alfaRomeoTop.jpg' | resize({ width:420, height:452})  | avif %}" alt="building a new wall" width="420" height="452">
                 </picture>
                 <picture class="cs-picture cs-picture-3">
                     <!--Mobile Image-->
@@ -715,7 +715,7 @@ permalink: "/motorsport/"
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/track1.jpg' | resize({ width:635, height:886}) | avif %}" type="image/avif">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/track1.jpg' | resize({ width:635, height:886}) | webp %}" type="image/webp">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/track1.jpg' | resize({ width:635, height:886}) | jpeg %}" type="image/jpeg">
-                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/track1.jpg' | resize({ width:420, height:629})  | avif %}" type="image/avif" alt="building a new wall" width="420" height="629">
+                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/track1.jpg' | resize({ width:420, height:629})  | avif %}" alt="building a new wall" width="420" height="629">
                 </picture>
                 <picture class="cs-picture cs-picture-1">
                     <!--Mobile Image-->
@@ -730,7 +730,7 @@ permalink: "/motorsport/"
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/hiddenPorsche.jpg' | resize({ width:635, height:880}) | avif %}" type="image/avif">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/hiddenPorsche.jpg' | resize({ width:635, height:880}) | webp %}" type="image/webp">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/hiddenPorsche.jpg' | resize({ width:635, height:880}) | jpeg %}" type="image/jpeg">
-                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/hiddenPorsche.jpg' | resize({ width:420, height:625})  | avif %}" type="image/avif" alt="building a new wall" width="420" height="625">
+                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/hiddenPorsche.jpg' | resize({ width:420, height:625})  | avif %}" alt="building a new wall" width="420" height="625">
                 </picture>
                 <picture class="cs-picture cs-picture-2">
                     <!--Mobile Image-->
@@ -745,7 +745,7 @@ permalink: "/motorsport/"
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/alfaRomeoTop.jpg' | resize({ width:635, height:636}) | avif %}" type="image/avif">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/alfaRomeoTop.jpg' | resize({ width:635, height:636}) | webp %}" type="image/webp">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/alfaRomeoTop.jpg' | resize({ width:635, height:636}) | jpeg %}" type="image/jpeg">
-                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/alfaRomeoTop.jpg' | resize({ width:420, height:452})  | avif %}" type="image/avif" alt="building a new wall" width="420" height="452">
+                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/alfaRomeoTop.jpg' | resize({ width:420, height:452})  | avif %}" alt="building a new wall" width="420" height="452">
                 </picture>
                 <picture class="cs-picture cs-picture-3">
                     <!--Mobile Image-->
@@ -760,7 +760,7 @@ permalink: "/motorsport/"
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/track1.jpg' | resize({ width:635, height:886}) | avif %}" type="image/avif">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/track1.jpg' | resize({ width:635, height:886}) | webp %}" type="image/webp">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/track1.jpg' | resize({ width:635, height:886}) | jpeg %}" type="image/jpeg">
-                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/track1.jpg' | resize({ width:420, height:629})  | avif %}" type="image/avif" alt="building a new wall" width="420" height="629">
+                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/track1.jpg' | resize({ width:420, height:629})  | avif %}" alt="building a new wall" width="420" height="629">
                 </picture>
                 <picture class="cs-picture cs-picture-1">
                     <!--Mobile Image-->
@@ -775,7 +775,7 @@ permalink: "/motorsport/"
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/hiddenPorsche.jpg' | resize({ width:635, height:880}) | avif %}" type="image/avif">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/hiddenPorsche.jpg' | resize({ width:635, height:880}) | webp %}" type="image/webp">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/hiddenPorsche.jpg' | resize({ width:635, height:880}) | jpeg %}" type="image/jpeg">
-                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/hiddenPorsche.jpg' | resize({ width:420, height:625})  | avif %}" type="image/avif" alt="building a new wall" width="420" height="625">
+                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/hiddenPorsche.jpg' | resize({ width:420, height:625})  | avif %}" alt="building a new wall" width="420" height="625">
                 </picture>
                 <picture class="cs-picture cs-picture-2">
                     <!--Mobile Image-->
@@ -790,7 +790,7 @@ permalink: "/motorsport/"
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/alfaRomeoTop.jpg' | resize({ width:635, height:636}) | avif %}" type="image/avif">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/alfaRomeoTop.jpg' | resize({ width:635, height:636}) | webp %}" type="image/webp">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/alfaRomeoTop.jpg' | resize({ width:635, height:636}) | jpeg %}" type="image/jpeg">
-                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/alfaRomeoTop.jpg' | resize({ width:420, height:452})  | avif %}" type="image/avif" alt="building a new wall" width="420" height="452">
+                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/alfaRomeoTop.jpg' | resize({ width:420, height:452})  | avif %}" alt="building a new wall" width="420" height="452">
                 </picture>
                 <picture class="cs-picture cs-picture-3">
                     <!--Mobile Image-->
@@ -805,7 +805,7 @@ permalink: "/motorsport/"
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/track1.jpg' | resize({ width:635, height:886}) | avif %}" type="image/avif">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/track1.jpg' | resize({ width:635, height:886}) | webp %}" type="image/webp">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/track1.jpg' | resize({ width:635, height:886}) | jpeg %}" type="image/jpeg">
-                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/track1.jpg' | resize({ width:420, height:629})  | avif %}" type="image/avif" alt="building a new wall" width="420" height="629">
+                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/track1.jpg' | resize({ width:420, height:629})  | avif %}" alt="building a new wall" width="420" height="629">
                 </picture>
                 <picture class="cs-picture cs-picture-1">
                     <!--Mobile Image-->
@@ -820,7 +820,7 @@ permalink: "/motorsport/"
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/hiddenPorsche.jpg' | resize({ width:635, height:880}) | avif %}" type="image/avif">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/hiddenPorsche.jpg' | resize({ width:635, height:880}) | webp %}" type="image/webp">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/hiddenPorsche.jpg' | resize({ width:635, height:880}) | jpeg %}" type="image/jpeg">
-                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/hiddenPorsche.jpg' | resize({ width:420, height:625})  | avif %}" type="image/avif" alt="building a new wall" width="420" height="625">
+                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/hiddenPorsche.jpg' | resize({ width:420, height:625})  | avif %}" alt="building a new wall" width="420" height="625">
                 </picture>
                 <picture class="cs-picture cs-picture-2">
                     <!--Mobile Image-->
@@ -835,7 +835,7 @@ permalink: "/motorsport/"
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/alfaRomeoTop.jpg' | resize({ width:635, height:636}) | avif %}" type="image/avif">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/alfaRomeoTop.jpg' | resize({ width:635, height:636}) | webp %}" type="image/webp">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/alfaRomeoTop.jpg' | resize({ width:635, height:636}) | jpeg %}" type="image/jpeg">
-                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/alfaRomeoTop.jpg' | resize({ width:420, height:452})  | avif %}" type="image/avif" alt="building a new wall" width="420" height="452">
+                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/alfaRomeoTop.jpg' | resize({ width:420, height:452})  | avif %}" alt="building a new wall" width="420" height="452">
                 </picture>
                 <picture class="cs-picture cs-picture-3">
                     <!--Mobile Image-->
@@ -850,7 +850,7 @@ permalink: "/motorsport/"
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/track1.jpg' | resize({ width:635, height:886}) | avif %}" type="image/avif">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/track1.jpg' | resize({ width:635, height:886}) | webp %}" type="image/webp">
                     <source media="(min-width: 1024px)" srcset="{% getUrl '/assets/images/track1.jpg' | resize({ width:635, height:886}) | jpeg %}" type="image/jpeg">
-                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/track1.jpg' | resize({ width:420, height:629})  | avif %}" type="image/avif" alt="building a new wall" width="420" height="629">
+                    <img loading="lazy" decoding="async" src="{% getUrl '/assets/images/track1.jpg' | resize({ width:420, height:629})  | avif %}" alt="building a new wall" width="420" height="629">
                 </picture>
 
                 <!-- To add more images, copy and paste this row's picture tags here in order from cs-picture-1 to cs-picture-3 and they will maintain the same layout-->


### PR DESCRIPTION
## Summary
- remove the invalid `type` attribute from `<img>` fallback elements in the motorsport and creative creation pages so the markup passes validation

## Testing
- npm run build:eleventy

------
https://chatgpt.com/codex/tasks/task_e_68e45930c6b88321b66191930c34df47