### PR TITLE
Fix Netlify contact form hidden input

### DIFF
--- a/src/content/pages/contact.html
+++ b/src/content/pages/contact.html
@@ -95,6 +95,7 @@ permalink: "/contact/"
         </div>
         <!--Form-->
         <form class="cs-form" name="Contact Form" method="post" netlify>
+            <input type="hidden" name="form-name" value="Contact Form">
             <label class="cs-label">
                 Name
                 <input class="cs-input" required type="text" id="name-1694" name="name" placeholder="Name">


### PR DESCRIPTION
## Summary
- add the required hidden `form-name` input to the Netlify contact form so it renders without an XHTML-style trailing slash

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e45ee617b8832182ad439657f31b4e